### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "ext-json": "*",
     "ext-curl": "*",
     "getvero/vero-php": "dev-master",
-    "illuminate/support": "^8.0|^9.0|^10.0"
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
   },
   "repositories": [
     {


### PR DESCRIPTION
Bump supported versions of `illuminate/support` to allow `composer update` to run when using Laravel 11.x - need to test around our Vero integration still